### PR TITLE
[#166358380] Rebase against origin master

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This gem has unexpectedly grown in popularity and I've gotten pretty busy, so I'
 
 In your gemfile:
 
-    gem 'stripe-ruby-mock', '~> 2.5.6', :require => 'stripe_mock'
+    gem 'stripe-ruby-mock', '~> 2.5.7', :require => 'stripe_mock'
 
 ## Features
 

--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -70,6 +70,7 @@ require 'stripe_mock/request_handlers/subscriptions.rb'
 require 'stripe_mock/request_handlers/tokens.rb'
 require 'stripe_mock/request_handlers/country_spec.rb'
 require 'stripe_mock/request_handlers/ephemeral_key.rb'
+require 'stripe_mock/request_handlers/products.rb'
 require 'stripe_mock/instance'
 
 require 'stripe_mock/test_strategies/base.rb'

--- a/lib/stripe_mock/api/webhooks.rb
+++ b/lib/stripe_mock/api/webhooks.rb
@@ -50,6 +50,8 @@ module StripeMock
         'charge.dispute.created',
         'charge.dispute.updated',
         'charge.dispute.closed',
+        'charge.dispute.funds_reinstated',
+        'charge.dispute.funds_withdrawn',
         'customer.source.created',
         'customer.source.deleted',
         'customer.source.updated',

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -510,6 +510,21 @@ module StripeMock
       }.merge(params)
     end
 
+    def self.mock_product(params = {})
+      {
+        id: "default_test_prod",
+        object: "product",
+        active: true,
+        created: 1556896214,
+        livemode: false,
+        metadata: {},
+        name: "Default Test Product",
+        statement_descriptor: "PRODUCT",
+        type: "service",
+        updated: 1556918200,
+      }.merge(params)
+    end
+
     def self.mock_recipient(cards, params={})
       rp_id = params[:id] || "test_rp_default"
       cards.each {|card| card[:recipient] = rp_id}

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -111,6 +111,7 @@ module StripeMock
         object: "customer",
         created: 1372126710,
         id: cus_id,
+        name: nil,
         livemode: false,
         delinquent: false,
         discount: nil,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -335,7 +335,7 @@ module StripeMock
       lines << Data.mock_line_item() if lines.empty?
       invoice = {
         id: 'in_test_invoice',
-        date: 1349738950,
+        created: 1349738950,
         period_end: 1349738950,
         period_start: 1349738950,
         lines: {
@@ -409,7 +409,7 @@ module StripeMock
       {
         id: "test_ii",
         object: "invoiceitem",
-        date: 1349738920,
+        created: 1349738920,
         amount: 1099,
         livemode: false,
         proration: false,

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -36,6 +36,7 @@ module StripeMock
     include StripeMock::RequestHandlers::InvoiceItems
     include StripeMock::RequestHandlers::Orders
     include StripeMock::RequestHandlers::Plans
+    include StripeMock::RequestHandlers::Products
     include StripeMock::RequestHandlers::Refunds
     include StripeMock::RequestHandlers::Recipients
     include StripeMock::RequestHandlers::Transfers
@@ -46,7 +47,8 @@ module StripeMock
 
     attr_reader :accounts, :balance, :balance_transactions, :bank_tokens, :charges, :coupons, :customers,
                 :disputes, :events, :invoices, :invoice_items, :orders, :plans, :recipients,
-                :refunds, :transfers, :payouts, :subscriptions, :country_spec, :subscriptions_items
+                :refunds, :transfers, :payouts, :subscriptions, :country_spec, :subscriptions_items,
+                :products
 
     attr_accessor :error_queue, :debug, :conversion_rate, :account_balance
 
@@ -65,6 +67,7 @@ module StripeMock
       @invoice_items = {}
       @orders = {}
       @plans = {}
+      @products = {}
       @recipients = {}
       @refunds = {}
       @transfers = {}

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -175,7 +175,8 @@ module StripeMock
       amount = params[:amount]
       unless amount.nil?
         # Fee calculation
-        params[:fee] ||= (30 + (amount.abs * 0.029).ceil) * (amount > 0 ? 1 : -1)
+        calculate_fees(params) unless params[:fee]
+        params[:net] = amount - params[:fee]
         params[:amount] = amount * @conversion_rate
       end
       @balance_transactions[id] = Data.mock_balance_transaction(params.merge(id: id))
@@ -195,6 +196,32 @@ module StripeMock
     def to_faraday_hash(hash)
       response = Struct.new(:data)
       response.new(hash)
+    end
+
+    def calculate_fees(params)
+      application_fee = params[:application_fee] || 0
+      params[:fee] = processing_fee(params[:amount]) + application_fee
+      params[:fee_details] = [
+        {
+          amount: processing_fee(params[:amount]),
+          application: nil,
+          currency: params[:currency] || StripeMock.default_currency,
+          description: "Stripe processing fees",
+          type: "stripe_fee"
+        }
+      ]
+      if application_fee
+        params[:fee_details] << {
+          amount: application_fee,
+          currency: params[:currency] || StripeMock.default_currency,
+          description: "Application fee",
+          type: "application_fee"
+        }
+      end
+    end
+
+    def processing_fee(amount)
+      (30 + (amount.abs * 0.029).ceil) * (amount > 0 ? 1 : -1)
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -13,9 +13,12 @@ module StripeMock
       end
 
       def new_charge(route, method_url, params, headers)
-        if params[:idempotency_key] && charges.any?
-          original_charge = charges.values.find { |c| c[:idempotency_key] == params[:idempotency_key]}
-          return charges[original_charge[:id]] if original_charge
+        if headers && headers[:idempotency_key]
+          params[:idempotency_key] = headers[:idempotency_key]
+          if charges.any?
+            original_charge = charges.values.find { |c| c[:idempotency_key] == headers[:idempotency_key]}
+            return charges[original_charge[:id]] if original_charge
+          end
         end
 
         id = new_id('ch')

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -41,7 +41,7 @@ module StripeMock
         end
 
         ensure_required_params(params)
-        bal_trans_params = { amount: params[:amount], source: id }
+        bal_trans_params = { amount: params[:amount], source: id, application_fee: params[:application_fee] }
 
         balance_transaction_id = new_balance_transaction('txn', bal_trans_params)
 

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -51,7 +51,7 @@ module StripeMock
           coupon = coupons[ params[:coupon] ]
           assert_existence :coupon, params[:coupon], coupon
 
-          add_coupon_to_customer(customers[params[:id]], coupon)
+          add_coupon_to_object(customers[params[:id]], coupon)
         end
 
         customers[ params[:id] ]
@@ -90,7 +90,7 @@ module StripeMock
           coupon = coupons[ params[:coupon] ]
           assert_existence :coupon, params[:coupon], coupon
 
-          add_coupon_to_customer(cus, coupon)
+          add_coupon_to_object(cus, coupon)
         end
 
         cus

--- a/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
@@ -1,18 +1,17 @@
 module StripeMock
   module RequestHandlers
     module Helpers
+      def add_coupon_to_object(object, coupon)
+        discount_attrs = {}.tap do |attrs|
+          attrs[object[:object]]         = object[:id]
+          attrs[:coupon]                 = coupon
+          attrs[:start]                  = Time.now.to_i
+          attrs[:end]                    = (DateTime.now >> coupon[:duration_in_months].to_i).to_time.to_i if coupon[:duration] == 'repeating'
+        end
 
-      def add_coupon_to_customer(customer, coupon)
-        customer[:discount] = {
-            coupon: coupon,
-            customer: customer[:id],
-            start: Time.now.to_i,
-        }
-        customer[:discount][:end] = (DateTime.now >> coupon[:duration_in_months]).to_time.to_i  if coupon[:duration].to_sym == :repeating && coupon[:duration_in_months]
-
-        customer
+        object[:discount] = Stripe::Discount.construct_from(discount_attrs)
+        object
       end
-
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -8,10 +8,12 @@ module StripeMock
 
       def resolve_subscription_changes(subscription, plans, customer, options = {})
         subscription.merge!(custom_subscription_params(plans, customer, options))
+        items = options[:items]
+        items = items.values if items.respond_to?(:values)
         subscription[:items][:data] = plans.map do |plan|
-          if options[:items] && options[:items].size == plans.size
-            quantity = options[:items] &&
-              options[:items].detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
+          if items && items.size == plans.size
+            quantity = items &&
+              items.detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
             Data.mock_subscription_item({ plan: plan, quantity: quantity })
           else
             Data.mock_subscription_item({ plan: plan })

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -30,7 +30,8 @@ module StripeMock
         start_time = options[:current_period_start] || now
         params = { customer: cus[:id], current_period_start: start_time, created: created_time }
         params.merge!({ :plan => (plans.size == 1 ? plans.first : nil) })
-        params.merge! options.select {|k,v| k =~ /application_fee_percent|quantity|metadata|tax_percent/}
+        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due/
+        params.merge! options.select {|k,v| k =~ keys_to_merge}
         # TODO: Implement coupon logic
 
         if (((plan && plan[:trial_period_days]) || 0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -32,6 +32,13 @@ module StripeMock
         params.merge!({ :plan => (plans.size == 1 ? plans.first : nil) })
         keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due/
         params.merge! options.select {|k,v| k =~ keys_to_merge}
+
+        if options[:cancel_at_period_end] == true
+          params.merge!(cancel_at_period_end: true, canceled_at: now)
+        elsif options[:cancel_at_period_end] == false
+          params.merge!(cancel_at_period_end: false, canceled_at: nil)
+        end
+
         # TODO: Implement coupon logic
 
         if (((plan && plan[:trial_period_days]) || 0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -138,7 +138,7 @@ module StripeMock
           id: new_id('in'),
           customer: customer[:id],
           discount: customer[:discount],
-          date: invoice_date,
+          created: invoice_date,
           starting_balance: customer[:account_balance],
           subscription: preview_subscription[:id],
           period_start: prorating ? invoice_date : preview_subscription[:current_period_start],

--- a/lib/stripe_mock/request_handlers/products.rb
+++ b/lib/stripe_mock/request_handlers/products.rb
@@ -1,0 +1,43 @@
+module StripeMock
+  module RequestHandlers
+    module Products
+      def self.included(base)
+        base.add_handler 'post /v1/products',        :create_product
+        base.add_handler 'get /v1/products/(.*)',    :retrieve_product
+        base.add_handler 'post /v1/products/(.*)',   :update_product
+        base.add_handler 'get /v1/products',         :list_products
+        base.add_handler 'delete /v1/products/(.*)', :destroy_product
+      end
+
+      def create_product(_route, _method_url, params, _headers)
+        params[:id] ||= new_id('prod')
+        products[params[:id]] = Data.mock_product(params)
+      end
+
+      def retrieve_product(route, method_url, _params, _headers)
+        id = method_url.match(route).captures.first
+        assert_existence :product, id, products[id]
+      end
+
+      def update_product(route, method_url, params, _headers)
+        id = method_url.match(route).captures.first
+        product = assert_existence :product, id, products[id]
+
+        product.merge!(params)
+      end
+
+      def list_products(_route, _method_url, params, _headers)
+        limit = params[:limit] || 10
+        Data.mock_list_object(products.values.take(limit), params)
+      end
+
+      def destroy_product(route, method_url, _params, _headers)
+        id = method_url.match(route).captures.first
+        assert_existence :product, id, products[id]
+
+        products.delete(id)
+        { id: id, object: 'product', deleted: true }
+      end
+    end
+  end
+end

--- a/lib/stripe_mock/request_handlers/refunds.rb
+++ b/lib/stripe_mock/request_handlers/refunds.rb
@@ -10,9 +10,12 @@ module StripeMock
       end
 
       def new_refund(route, method_url, params, headers)
-        if params[:idempotency_key] && refunds.any?
-          original_refund = refunds.values.find { |c| c[:idempotency_key] == params[:idempotency_key]}
-          return refunds[original_refund[:id]] if original_refund
+        if headers && headers[:idempotency_key]
+          params[:idempotency_key] = headers[:idempotency_key]
+          if refunds.any?
+            original_refund = refunds.values.find { |c| c[:idempotency_key] == headers[:idempotency_key]}
+            return refunds[original_refund[:id]] if original_refund
+          end
         end
 
         charge = assert_existence :charge, params[:charge], charges[params[:charge]]

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -189,6 +189,7 @@ module StripeMock
         end
 
         params[:current_period_start] = subscription[:current_period_start]
+        params[:trial_end] = params[:trial_end] || subscription[:trial_end]
         subscription = resolve_subscription_changes(subscription, subscription_plans, customer, params)
 
         # delete the old subscription, replace with the new subscription

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -95,7 +95,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -60,7 +60,7 @@ module StripeMock
           coupon = coupons[coupon_id]
 
           if coupon
-            subscription[:discount] = Stripe::Util.convert_to_stripe_object({ coupon: coupon }, {})
+            add_coupon_to_object(subscription, coupon)
           else
             raise Stripe::InvalidRequestError.new("No such coupon: #{coupon_id}", 'coupon', http_status: 400)
           end
@@ -117,7 +117,7 @@ module StripeMock
           coupon = coupons[coupon_id]
 
           if coupon
-            subscription[:discount] = Stripe::Util.convert_to_stripe_object({ coupon: coupon }, {})
+            add_coupon_to_object(subscription, coupon)
           else
             raise Stripe::InvalidRequestError.new("No such coupon: #{coupon_id}", 'coupon', http_status: 400)
           end
@@ -174,9 +174,9 @@ module StripeMock
 
           coupon = coupons[coupon_id]
           if coupon
-            subscription[:discount] = Stripe::Util.convert_to_stripe_object({ coupon: coupon }, {})
+            add_coupon_to_object(subscription, coupon)
           elsif coupon_id == ""
-            subscription[:discount] = Stripe::Util.convert_to_stripe_object(nil, {})
+            subscription[:discount] = nil
           else
             raise Stripe::InvalidRequestError.new("No such coupon: #{coupon_id}", 'coupon', http_status: 400)
           end

--- a/lib/stripe_mock/request_handlers/tokens.rb
+++ b/lib/stripe_mock/request_handlers/tokens.rb
@@ -46,12 +46,12 @@ module StripeMock
         end
 
         if bank_account
-          token_id = generate_bank_token(bank_account)
+          token_id = generate_bank_token(bank_account.dup)
           bank_account = @bank_tokens[token_id]
 
           Data.mock_bank_account_token(params.merge :id => token_id, :bank_account => bank_account)
         else
-          token_id = generate_card_token(customer_card)
+          token_id = generate_card_token(customer_card.dup)
           card = @card_tokens[token_id]
 
           Data.mock_card_token(params.merge :id => token_id, :card => card)

--- a/lib/stripe_mock/version.rb
+++ b/lib/stripe_mock/version.rb
@@ -1,4 +1,4 @@
 module StripeMock
   # stripe-ruby-mock version
-  VERSION = "2.5.6"
+  VERSION = "2.5.7"
 end

--- a/lib/stripe_mock/webhook_fixtures/charge.dispute.funds_reinstated.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.dispute.funds_reinstated.json
@@ -1,0 +1,88 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "charge.dispute.funds_reinstated",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2017-12-14",
+  "data": {
+    "object": {
+      "id": "dp_00000000000000",
+      "object": "dispute",
+      "amount": 25000,
+      "balance_transaction": "txn_00000000000000",
+      "balance_transactions": [
+        {
+          "id": "txn_1Bl3mMGWCopOTFn18p8iALq8",
+          "object": "balance_transaction",
+          "amount": -25000,
+          "available_on": 1516233600,
+          "created": 1516145022,
+          "currency": "usd",
+          "description": "Chargeback withdrawal for ch_1Bl3mKGWCopOTFn1LKoN557r",
+          "exchange_rate": null,
+          "fee": 1500,
+          "fee_details": [
+            {
+              "amount": 1500,
+              "application": null,
+              "currency": "usd",
+              "description": "Dispute fee",
+              "type": "stripe_fee"
+            }
+          ],
+          "net": -26500,
+          "source": "dp_1Bl3mMGWCopOTFn1jpVaJDrU",
+          "status": "pending",
+          "type": "adjustment"
+        }
+      ],
+      "charge": "ch_00000000000000",
+      "created": 1516145022,
+      "currency": "usd",
+      "evidence": {
+        "access_activity_log": null,
+        "billing_address": null,
+        "cancellation_policy": null,
+        "cancellation_policy_disclosure": null,
+        "cancellation_rebuttal": null,
+        "customer_communication": null,
+        "customer_email_address": "amitree.apu@gmail.com",
+        "customer_name": "amitree.apu@gmail.com",
+        "customer_purchase_ip": "157.131.133.10",
+        "customer_signature": null,
+        "duplicate_charge_documentation": null,
+        "duplicate_charge_explanation": null,
+        "duplicate_charge_id": null,
+        "product_description": null,
+        "receipt": null,
+        "refund_policy": null,
+        "refund_policy_disclosure": null,
+        "refund_refusal_explanation": null,
+        "service_date": null,
+        "service_documentation": null,
+        "shipping_address": null,
+        "shipping_carrier": null,
+        "shipping_date": null,
+        "shipping_documentation": null,
+        "shipping_tracking_number": null,
+        "uncategorized_file": null,
+        "uncategorized_text": null
+      },
+      "evidence_details": {
+        "due_by": 1517529599,
+        "has_evidence": false,
+        "past_due": false,
+        "submission_count": 0
+      },
+      "is_charge_refundable": false,
+      "livemode": false,
+      "metadata": {
+      },
+      "reason": "fraudulent",
+      "status": "needs_response"
+    }
+  }
+}

--- a/lib/stripe_mock/webhook_fixtures/charge.dispute.funds_withdrawn.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.dispute.funds_withdrawn.json
@@ -1,0 +1,88 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "charge.dispute.funds_withdrawn",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2017-12-14",
+  "data": {
+    "object": {
+      "id": "dp_00000000000000",
+      "object": "dispute",
+      "amount": 25000,
+      "balance_transaction": "txn_00000000000000",
+      "balance_transactions": [
+        {
+          "id": "txn_1Bl3mMGWCopOTFn18p8iALq8",
+          "object": "balance_transaction",
+          "amount": -25000,
+          "available_on": 1516233600,
+          "created": 1516145022,
+          "currency": "usd",
+          "description": "Chargeback withdrawal for ch_1Bl3mKGWCopOTFn1LKoN557r",
+          "exchange_rate": null,
+          "fee": 1500,
+          "fee_details": [
+            {
+              "amount": 1500,
+              "application": null,
+              "currency": "usd",
+              "description": "Dispute fee",
+              "type": "stripe_fee"
+            }
+          ],
+          "net": -26500,
+          "source": "dp_1Bl3mMGWCopOTFn1jpVaJDrU",
+          "status": "pending",
+          "type": "adjustment"
+        }
+      ],
+      "charge": "ch_00000000000000",
+      "created": 1516145022,
+      "currency": "usd",
+      "evidence": {
+        "access_activity_log": null,
+        "billing_address": null,
+        "cancellation_policy": null,
+        "cancellation_policy_disclosure": null,
+        "cancellation_rebuttal": null,
+        "customer_communication": null,
+        "customer_email_address": "amitree.apu@gmail.com",
+        "customer_name": "amitree.apu@gmail.com",
+        "customer_purchase_ip": "157.131.133.10",
+        "customer_signature": null,
+        "duplicate_charge_documentation": null,
+        "duplicate_charge_explanation": null,
+        "duplicate_charge_id": null,
+        "product_description": null,
+        "receipt": null,
+        "refund_policy": null,
+        "refund_policy_disclosure": null,
+        "refund_refusal_explanation": null,
+        "service_date": null,
+        "service_documentation": null,
+        "shipping_address": null,
+        "shipping_carrier": null,
+        "shipping_date": null,
+        "shipping_documentation": null,
+        "shipping_tracking_number": null,
+        "uncategorized_file": null,
+        "uncategorized_text": null
+      },
+      "evidence_details": {
+        "due_by": 1517529599,
+        "has_evidence": false,
+        "past_due": false,
+        "submission_count": 0
+      },
+      "is_charge_refundable": false,
+      "livemode": false,
+      "metadata": {
+      },
+      "reason": "fraudulent",
+      "status": "needs_response"
+    }
+  }
+}

--- a/lib/stripe_mock/webhook_fixtures/invoice.created.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.created.json
@@ -6,7 +6,7 @@
   "object": "event",
   "data": {
     "object": {
-      "date": 1380674206,
+      "created": 1380674206,
       "id": "in_00000000000000",
       "period_start": 1378082075,
       "period_end": 1380674075,

--- a/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
@@ -16,7 +16,7 @@
       "closed": true,
       "currency": "eur",
       "customer": "cus_00000000000000",
-      "date": 1464084258,
+      "created": 1464084258,
       "description": null,
       "discount": null,
       "ending_balance": 0,

--- a/lib/stripe_mock/webhook_fixtures/invoice.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.updated.json
@@ -6,7 +6,7 @@
   "object": "event",
   "data": {
     "object": {
-      "date": 1380674206,
+      "created": 1380674206,
       "id": "in_00000000000000",
       "period_start": 1378082075,
       "period_end": 1380674075,

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -163,15 +163,19 @@ shared_examples 'Charge API' do
   end
 
   it "creates a balance transaction" do
+    amount = 300
+    fee = 10
     charge = Stripe::Charge.create({
-      amount: 300,
+      amount: amount,
       currency: 'USD',
-      source: stripe_helper.generate_card_token
+      source: stripe_helper.generate_card_token,
+      application_fee: fee,
     })
     bal_trans = Stripe::BalanceTransaction.retrieve(charge.balance_transaction)
-    expect(bal_trans.amount).to eq(charge.amount)
-    expect(bal_trans.fee).to eq(39)
+    expect(bal_trans.amount).to eq(amount)
+    expect(bal_trans.fee).to eq(39 + fee)
     expect(bal_trans.source).to eq(charge.id)
+    expect(bal_trans.net).to eq(amount - bal_trans.fee)
   end
 
   context 'when conversion rate is set' do

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -226,7 +226,7 @@ shared_examples 'Customer API' do
       discount = Stripe::Customer.retrieve(customer.id).discount
       expect(discount).to_not be_nil
       expect(discount.coupon).to_not be_nil
-      expect(discount.end).to be_within(1).of (Time.now + 365 * 24 * 3600).to_i
+      expect(discount.end).to be_within(1).of (Time.now.to_datetime >> 12).to_time.to_i
     end
     after { Stripe::Coupon.retrieve(coupon.id).delete }
     after { Stripe::Customer.retrieve(customer.id).delete }

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -78,6 +78,15 @@ shared_examples 'Customer API' do
     expect(customer.sources.data.first.exp_year).to eq 2024
   end
 
+  it 'creates a customer with name' do
+    customer = Stripe::Customer.create(
+      source: gen_card_tk,
+      name: 'John Appleseed'
+    )
+    expect(customer.id).to match(/^test_cus/)
+    expect(customer.name).to eq('John Appleseed')
+  end
+
   it 'creates a customer with a plan' do
     plan = stripe_helper.create_plan(id: 'silver')
     customer = Stripe::Customer.create(id: 'test_cus_plan', source: gen_card_tk, :plan => 'silver')
@@ -267,6 +276,7 @@ shared_examples 'Customer API' do
 
     expect(customer.id).to eq(original.id)
     expect(customer.email).to eq(original.email)
+    expect(customer.name).to eq(nil)
     expect(customer.default_source).to eq(original.default_source)
     expect(customer.default_source).not_to be_a(Stripe::Card)
     expect(customer.subscriptions.count).to eq(0)

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -351,7 +351,7 @@ shared_examples 'Invoice API' do
         it 'generates a preview without performing an actual proration', live: true do
           expect(preview.subtotal).to eq 150_00
           # this is a future invoice (generted at the end of the current subscription cycle), rather than a proration invoice
-          expect(preview.date).to be_within(1).of subscription.current_period_end
+          expect(preview.created).to be_within(1).of subscription.current_period_end
           expect(preview.period_start).to eq subscription.current_period_start
           expect(preview.period_end).to eq subscription.current_period_end
           expect(preview.lines.count).to eq 1

--- a/spec/shared_stripe_examples/plan_examples.rb
+++ b/spec/shared_stripe_examples/plan_examples.rb
@@ -157,7 +157,7 @@ shared_examples 'Plan API' do
         expect { subject }.to raise_error(Stripe::InvalidRequestError, message)
       end
 
-      it("requires a name") { @name = :name }
+      it("requires a product") { @name = :product }
       it("requires an amount") { @name = :amount }
       it("requires a currency") { @name = :currency }
       it("requires an interval") { @name = :interval }

--- a/spec/shared_stripe_examples/product_example.rb
+++ b/spec/shared_stripe_examples/product_example.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+shared_examples 'Product API' do
+  it 'creates a product' do
+    product = Stripe::Product.create(
+      name: 'my awesome product',
+      type: 'service'
+    )
+
+    expect(product.name).to eq 'my awesome product'
+    expect(product.type).to eq 'service'
+  end
+
+  it 'retrieves a product' do
+    Stripe::Product.create(
+      id:   'test_prod_1',
+      name: 'my awesome product',
+      type: 'service'
+    )
+
+    product = Stripe::Product.retrieve('test_prod_1')
+
+    expect(product.name).to eq 'my awesome product'
+    expect(product.type).to eq 'service'
+  end
+
+  it 'updates a product' do
+    Stripe::Product.create(
+      id:   'test_prod_1',
+      name: 'my awesome product',
+      type: 'service'
+    )
+
+    Stripe::Product.update('test_prod_1', name: 'my lame product')
+
+    product = Stripe::Product.retrieve('test_prod_1')
+
+    expect(product.name).to eq 'my lame product'
+  end
+
+  it 'lists all products' do
+    2.times do |n|
+      Stripe::Product.create(
+        name: "product #{n}",
+        type: 'service'
+      )
+    end
+
+    products = Stripe::Product.list
+
+    expect(products.map(&:name)).to match_array ['product 0', 'product 1']
+  end
+
+  it 'destroys a product', live: true do
+    Stripe::Product.create(
+      id:   'test_prod_1',
+      name: 'my awesome product',
+      type: 'service'
+    )
+
+    Stripe::Product.delete('test_prod_1')
+
+    expect { Stripe::Product.retrieve('test_prod_1') }. to raise_error(Stripe::InvalidRequestError)
+  end
+end

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -337,26 +337,32 @@ shared_examples 'Refund API' do
           capture: true
         )
       end
-      let(:idempotent_refund_params) {{
-        charge: charge.id,
+      let(:refund_params) {{
+        charge: charge.id
+      }}
+
+      let(:refund_headers) {{
         idempotency_key: 'onceisenough'
       }}
 
       it "returns the original refund if the same idempotency_key is passed in" do
-        refund1 = Stripe::Refund.create(idempotent_refund_params)
-        refund2 = Stripe::Refund.create(idempotent_refund_params)
+        refund1 = Stripe::Refund.create(refund_params, refund_headers)
+        refund2 = Stripe::Refund.create(refund_params, refund_headers)
 
         expect(refund1).to eq(refund2)
       end
 
-      it "returns different charges if different idempotency_keys are used for each charge" do
-        idempotent_refund_params2 = idempotent_refund_params.clone
-        idempotent_refund_params2[:idempotency_key] = 'thisoneisdifferent'
+      context 'different key' do
+        let(:different_refund_headers) {{
+          idempotency_key: 'thisoneisdifferent'
+        }}
 
-        refund1 = Stripe::Refund.create(idempotent_refund_params)
-        refund2 = Stripe::Refund.create(idempotent_refund_params2)
+        it "returns different charges if different idempotency_keys are used for each charge" do
+          refund1 = Stripe::Refund.create(refund_params, refund_headers)
+          refund2 = Stripe::Refund.create(refund_params, different_refund_headers)
 
-        expect(refund1).not_to eq(refund2)
+          expect(refund1).not_to eq(refund2)
+        end
       end
     end
   end

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -472,6 +472,28 @@ shared_examples 'Customer Subscriptions' do
       expect(subscription.items.data[0].plan.id).to eq plan.id
       expect(subscription.items.data[1].plan.id).to eq plan2.id
     end
+
+    it 'add a new subscription to bill via an invoice' do
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
+      customer = Stripe::Customer.create(source: gen_card_tk)
+
+      expect(customer.subscriptions.data).to be_empty
+      expect(customer.subscriptions.count).to eq(0)
+
+      sub = Stripe::Subscription.create({
+        plan: 'silver',
+        customer: customer.id,
+        metadata: { foo: 'bar', example: 'yes' },
+        billing: 'send_invoice',
+        days_until_due: 30,
+      })
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan.to_hash).to eq(plan.to_hash)
+      expect(sub.billing).to eq 'send_invoice'
+      expect(sub.days_until_due).to eq 30
+    end
   end
 
   context "updating a subscription" do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -140,7 +140,7 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data).to be_a(Array)
       expect(customer.subscriptions.data.count).to eq(1)
       expect(customer.subscriptions.data.first.discount).not_to be_nil
-      expect(customer.subscriptions.data.first.discount).to be_a(Stripe::StripeObject)
+      expect(customer.subscriptions.data.first.discount).to be_a(Stripe::Discount)
       expect(customer.subscriptions.data.first.discount.coupon.id).to eq(coupon.id)
     end
 
@@ -614,7 +614,7 @@ shared_examples 'Customer Subscriptions' do
       subscription.save
 
       expect(subscription.discount).not_to be_nil
-      expect(subscription.discount).to be_an_instance_of(Stripe::StripeObject)
+      expect(subscription.discount).to be_a(Stripe::Discount)
       expect(subscription.discount.coupon.id).to eq(coupon.id)
     end
 

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -476,7 +476,7 @@ shared_examples 'Customer Subscriptions' do
     it 'add a new subscription to bill via an invoice' do
       plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
                                        amount: 4999, currency: 'usd')
-      customer = Stripe::Customer.create(source: gen_card_tk)
+      customer = Stripe::Customer.create(id: 'cardless')
 
       expect(customer.subscriptions.data).to be_empty
       expect(customer.subscriptions.count).to eq(0)

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -552,6 +552,18 @@ shared_examples 'Customer Subscriptions' do
       sub2 = Stripe::Subscription.create({ items: [{ plan: 'silver' }], customer: customer.id }, another_subscription_header)
       expect(sub1).not_to eq(sub2)
     end
+
+    it "accepts a hash of items" do
+      silver = stripe_helper.create_plan(id: 'silver')
+      customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk)
+
+      sub = Stripe::Subscription.create({ items: { '0' => { plan: 'silver' } }, customer: customer.id })
+      sub.delete(at_period_end: true)
+
+      expect(sub.cancel_at_period_end).to be_truthy
+      expect(sub.save).to be_truthy
+      expect(sub.cancel_at_period_end).to be_falsey
+    end
   end
 
   context "updating a subscription" do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -494,6 +494,40 @@ shared_examples 'Customer Subscriptions' do
       expect(sub.billing).to eq 'send_invoice'
       expect(sub.days_until_due).to eq 30
     end
+
+    let(:subscription_header) {{
+      :idempotency_key => 'a_idempotency_key'
+    }}
+
+    it "adds a new subscription to customer with identical idempotency key" do
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
+      customer = Stripe::Customer.create(source: gen_card_tk)
+
+      expect(customer.subscriptions.data).to be_empty
+      expect(customer.subscriptions.count).to eq(0)
+
+      sub1 = Stripe::Subscription.create({ items: [{ plan: 'silver' }], customer: customer.id }, subscription_header)
+      sub2 = Stripe::Subscription.create({ items: [{ plan: 'silver' }], customer: customer.id }, subscription_header)
+      expect(sub1).to eq(sub2)
+    end
+
+    it "adds a new subscription to customer with different idempotency key", :live => true do
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
+      customer = Stripe::Customer.create(source: gen_card_tk)
+
+      expect(customer.subscriptions.data).to be_empty
+      expect(customer.subscriptions.count).to eq(0)
+
+      another_subscription_header = {
+        :idempotency_key => 'another_idempotency_key'
+      }
+
+      sub1 = Stripe::Subscription.create({ items: [{ plan: 'silver' }], customer: customer.id }, subscription_header)
+      sub2 = Stripe::Subscription.create({ items: [{ plan: 'silver' }], customer: customer.id }, another_subscription_header)
+      expect(sub1).not_to eq(sub2)
+    end
   end
 
   context "updating a subscription" do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -913,6 +913,52 @@ shared_examples 'Customer Subscriptions' do
     end
   end
 
+  it "supports 'cancelling' by updating cancel_at_period_end" do
+    truth = stripe_helper.create_plan(id: 'the_truth')
+    customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: "the_truth")
+
+    sub = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+    result = Stripe::Subscription.update(sub.id, cancel_at_period_end: true)
+
+    expect(result.status).to eq('active')
+    expect(result.cancel_at_period_end).to eq(true)
+    expect(result.id).to eq(sub.id)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.subscriptions.data).to_not be_empty
+    expect(customer.subscriptions.count).to eq(1)
+    expect(customer.subscriptions.data.length).to eq(1)
+
+    expect(customer.subscriptions.data.first.status).to eq('active')
+    expect(customer.subscriptions.data.first.cancel_at_period_end).to eq(true)
+    expect(customer.subscriptions.data.first.ended_at).to be_nil
+    expect(customer.subscriptions.data.first.canceled_at).to_not be_nil
+  end
+
+  it "resumes a subscription cancelled by updating cancel_at_period_end" do
+    truth = stripe_helper.create_plan(id: 'the_truth')
+    customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: "the_truth")
+
+    sub = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+    Stripe::Subscription.update(sub.id, cancel_at_period_end: true)
+
+    result = Stripe::Subscription.update(sub.id, cancel_at_period_end: false)
+
+    expect(result.status).to eq('active')
+    expect(result.cancel_at_period_end).to eq(false)
+    expect(result.id).to eq(sub.id)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.subscriptions.data).to_not be_empty
+    expect(customer.subscriptions.count).to eq(1)
+    expect(customer.subscriptions.data.length).to eq(1)
+
+    expect(customer.subscriptions.data.first.status).to eq('active')
+    expect(customer.subscriptions.data.first.cancel_at_period_end).to eq(false)
+    expect(customer.subscriptions.data.first.ended_at).to be_nil
+    expect(customer.subscriptions.data.first.canceled_at).to be_nil
+  end
+
   it "doesn't change status of subscription when cancelling at period end" do
     trial = stripe_helper.create_plan(id: 'trial', trial_period_days: 14)
     customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: "trial")

--- a/spec/shared_stripe_examples/transfer_examples.rb
+++ b/spec/shared_stripe_examples/transfer_examples.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 shared_examples 'Transfer API' do
 
   it "creates a stripe transfer" do
-    destination = Stripe::Account.create(email: "#{SecureRandom.uuid}@example.com", id: "acct_12345")
+    destination = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", id: "acct_12345")
     transfer = Stripe::Transfer.create(amount: 100, currency: "usd", destination: destination.id)
 
     expect(transfer.id).to match /^test_tr/
@@ -31,7 +31,7 @@ shared_examples 'Transfer API' do
   end
 
   describe "listing transfers" do
-    let(:destination) { Stripe::Account.create(email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo") }
+    let(:destination) { Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo") }
 
     before do
       3.times do
@@ -48,7 +48,7 @@ shared_examples 'Transfer API' do
     end
 
     it "filters the search to a specific destination" do
-      d2 = Stripe::Account.create(email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo")
+      d2 = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo")
       Stripe::Transfer.create(amount: "100", currency: "usd", destination: d2.id)
 
       expect(Stripe::Transfer.all(destination: d2.id).count).to eq(1)
@@ -104,7 +104,7 @@ shared_examples 'Transfer API' do
   end
 
   it "when amount is not integer", live: true do
-    dest = Stripe::Account.create(type: "standard", email: "#{SecureRandom.uuid}@example.com", business_name: "Alex Smith")
+    dest = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "Alex Smith")
     expect { Stripe::Transfer.create(amount: '400.2',
                                      currency: 'usd',
                                      destination: dest.id,
@@ -116,7 +116,7 @@ shared_examples 'Transfer API' do
   end
 
   it "when amount is negative", live: true do
-    dest = Stripe::Account.create(type: "standard", email: "#{SecureRandom.uuid}@example.com", business_name: "Alex Smith")
+    dest = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "Alex Smith")
     expect { Stripe::Transfer.create(amount: '-400',
                                      currency: 'usd',
                                      destination: dest.id,

--- a/spec/support/stripe_examples.rb
+++ b/spec/support/stripe_examples.rb
@@ -1,4 +1,3 @@
-
 def require_stripe_examples
   Dir["./spec/shared_stripe_examples/**/*.rb"].each {|f| require f}
   Dir["./spec/integration_examples/**/*.rb"].each {|f| require f}
@@ -21,6 +20,7 @@ def it_behaves_like_stripe(&block)
   it_behaves_like 'Invoice API', &block
   it_behaves_like 'Invoice Item API', &block
   it_behaves_like 'Plan API', &block
+  it_behaves_like 'Product API', &block
   it_behaves_like 'Recipient API', &block
   it_behaves_like 'Refund API', &block
   it_behaves_like 'Transfer API', &block


### PR DESCRIPTION
We need to support an updated version of this library for rails 5, so this is a rebase against the updated master.

Because this is a rebase it's hard to read. Here's a more accurate view of the end state:
https://github.com/rebelidealist/stripe-ruby-mock/compare/master...amitree:nh-source-update

We probably need to force push this on top of `master`.